### PR TITLE
Added new comand line option -B <address> for binding specified address when connect to DNS server via TCP

### DIFF
--- a/dns2tcp.c
+++ b/dns2tcp.c
@@ -134,7 +134,7 @@ enum {
     OPT_IPV6_V6ONLY = 1 << 0,
     OPT_REUSE_PORT  = 1 << 1,
     OPT_VERBOSE     = 1 << 2,
-    OPT_BIND_TCP    = 1 << 4,
+    OPT_BIND_TCP    = 1 << 3,
 };
 
 #define has_opt(opt) (g_options & (opt))
@@ -429,7 +429,7 @@ static void udp_recvmsg_cb(evloop_t *evloop, evio_t *watcher __unused, int event
     if (has_opt(OPT_BIND_TCP)) {
 	    if (bind(sockfd, &g_bind_skaddr.sa, skaddr_len(&g_bind_skaddr)) < 0) {
 		    log_error("bind tcp address: %m");
-		    return 1;
+		    goto close_sockfd;
 	    }
     }
 

--- a/dns2tcp.c
+++ b/dns2tcp.c
@@ -264,7 +264,7 @@ static void parse_opt(int argc, char *argv[]) {
                 break;
             case 'B':
                 if (strlen(optarg) + 1 > IP6STRLEN + PORTSTRLEN) {
-                    printf("invalid remote addr: %s\n", optarg);
+                    printf("invalid bind addr: %s\n", optarg);
                     goto err;
                 }
                 strcpy(opt_bind_addr, optarg);
@@ -378,7 +378,7 @@ int main(int argc, char *argv[]) {
 
     log_info("udp listen addr: %s#%hu", g_listen_ipstr, g_listen_port);
     log_info("tcp remote addr: %s#%hu", g_remote_ipstr, g_remote_port);
-    if has_opt(OPT_BIND_TCP) log_info("tcp  bind  addr: %s#%hu", g_bind_ipstr, g_bind_port);
+    if has_opt(OPT_BIND_TCP) log_info("tcp bind addr: %s#%hu", g_bind_ipstr, g_bind_port);
     if (g_syn_maxcnt) log_info("enable TCP_SYNCNT:%hhu sockopt", g_syn_maxcnt);
     if (has_opt(OPT_IPV6_V6ONLY)) log_info("enable IPV6_V6ONLY sockopt");
     if (has_opt(OPT_REUSE_PORT)) log_info("enable SO_REUSEPORT sockopt");
@@ -432,6 +432,7 @@ static void udp_recvmsg_cb(evloop_t *evloop, evio_t *watcher __unused, int event
             goto close_sockfd;
         }
     }
+
     if (connect(sockfd, &g_remote_skaddr.sa, skaddr_len(&g_remote_skaddr)) < 0 && errno != EINPROGRESS) {
         log_warning("connect to %s#%hu: %m", g_remote_ipstr, g_remote_port);
         goto close_sockfd;

--- a/dns2tcp.c
+++ b/dns2tcp.c
@@ -167,7 +167,7 @@ static void print_help(void) {
     printf("usage: dns2tcp <-L listen> <-R remote> [-s syncnt] [-6rvVh]\n"
            " -L <ip[#port]>          udp listen address, this is required\n"
            " -R <ip[#port]>          tcp remote address, this is required\n"
-	   " -B <ip>                 bind address for tcp connection\n"
+           " -B <ip>                 bind address for tcp connection\n"
            " -s <syncnt>             set TCP_SYNCNT(max) for remote socket\n"
            " -6                      enable IPV6_V6ONLY for listen socket\n"
            " -r                      enable SO_REUSEPORT for listen socket\n"
@@ -210,11 +210,11 @@ static void parse_addr(const char *addr, int addr_type) {
         g_remote_port = port;
         skaddr_from_text(&g_remote_skaddr, family, ipstr, port);
     }
-    if (addr_type == 2){
+    if (addr_type == 2) {
         strcpy(g_bind_ipstr, ipstr);
-	port = 0;
+        port = 0;
         g_bind_port = port;
-	if (portlen >= 0) log_info("Ignore port when binding address (set to zero)");
+        if (portlen >= 0) log_info("Ignore port when binding address (set to zero)");
         skaddr_from_text(&g_bind_skaddr, family, ipstr, port);
     }
     return;
@@ -222,15 +222,15 @@ static void parse_addr(const char *addr, int addr_type) {
 err:;
     const char *type;
     switch (addr_type) {
-	    case 0:
-		    type = "listen";
-		    break;
-            case 1:
-		    type = "remote";
-		    break;
-	    case 2:
-		    type = "bind";
-		    break;
+        case 0:
+            type = "listen";
+            break;
+        case 1:
+            type = "remote";
+            break;
+        case 2:
+            type = "bind";
+            break;
     }
 
     printf("invalid %s address: '%s'\n", type, addr);
@@ -262,14 +262,14 @@ static void parse_opt(int argc, char *argv[]) {
                 }
                 strcpy(opt_remote_addr, optarg);
                 break;
-	    case 'B':
-		if (strlen(optarg) + 1 > IP6STRLEN + PORTSTRLEN) {
+            case 'B':
+                if (strlen(optarg) + 1 > IP6STRLEN + PORTSTRLEN) {
                     printf("invalid remote addr: %s\n", optarg);
                     goto err;
                 }
                 strcpy(opt_bind_addr, optarg);
-		enable_opt(OPT_BIND_TCP);
-		break;
+                enable_opt(OPT_BIND_TCP);
+                break;
             case 's':
                 g_syn_maxcnt = strtoul(optarg, NULL, 10);
                 if (g_syn_maxcnt == 0) {
@@ -427,13 +427,11 @@ static void udp_recvmsg_cb(evloop_t *evloop, evio_t *watcher __unused, int event
         goto free_ctx;
 
     if (has_opt(OPT_BIND_TCP)) {
-	    if (bind(sockfd, &g_bind_skaddr.sa, skaddr_len(&g_bind_skaddr)) < 0) {
-		    log_error("bind tcp address: %m");
-		    goto close_sockfd;
-	    }
+        if (bind(sockfd, &g_bind_skaddr.sa, skaddr_len(&g_bind_skaddr)) < 0) {
+            log_error("bind tcp address: %m");
+            goto close_sockfd;
+        }
     }
-
-
     if (connect(sockfd, &g_remote_skaddr.sa, skaddr_len(&g_remote_skaddr)) < 0 && errno != EINPROGRESS) {
         log_warning("connect to %s#%hu: %m", g_remote_ipstr, g_remote_port);
         goto close_sockfd;


### PR DESCRIPTION
Added a new command line option -B <address>. This will allow you to configure traffic routing from dns2tsp through the desired network interface. Or even several copies of dns2tsp (listening on different UDP ports or bound to different network interfaces via the -L option) can be launched simultaneously with binding to different interfaces (by their IP addresses), which will allow routing traffic to the same DNS server (e.g. 8.8.8.8) through different network interfaces using the so-called policy-based routing. For these purposes, simply run several copies of the dns2tsp with different and -B <address> options, where <address> is the address of the desired network interface. And then use `ip route` and `ip rule` commands to route traffic to DNS server as you wish.